### PR TITLE
404 Page

### DIFF
--- a/404.html
+++ b/404.html
@@ -56,7 +56,7 @@
     </picture>
     <h1>Sorry, page not found</h1>
     <div>
-        <p>Page not found (404)</p>
+        <p><strong>Page not found (404)</strong></p>
         <p>This page may have been removed, had its name changed or is temporarily unavailable</p>
         <ul>
             <li>
@@ -67,16 +67,56 @@
             </li>
         </ul>
     </div>
-    <div class="cards">
-        <div>
-            <h2>Find your nearest Centre</h2>
-            <img src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-finden.jpg"
-                 alt="320x110_Haendler-finden.jpg">
-            <button>Locate a Centre ></button>
+    <div class="cards-wrapper">
+        <div class="cards block" data-block-name="cards">
+            <ul>
+                <li>
+                    <div class="cards-card-image">
+                        <picture>
+                            <img loading="lazy" alt="320x110_Haendler-finden.jpg"
+                                 src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-finden.jpg">
+                        </picture>
+                    </div>
+                    <div class="cards-card-body">
+                        <p><strong>Find your nearest Centre</strong></p>
+                        <p class="button-container">
+                            <em>
+                                <a href="https://www.audi.co.uk/uk/web/en/locate-a-centre.html"
+                                   title="Locate a Centre" class="button secondary">
+                                    Locate a Centre
+                                </a>
+                            </em>
+                        </p>
+                    </div>
+                </li>
+            </ul>
+        </div>
+
+        <div class="cards block" data-block-name="cards">
+            <ul>
+                <li>
+                    <div class="cards-card-image">
+                        <picture>
+                            <img loading="lazy" alt="320x110_Haendler-kontaktieren.jpg"
+                                 src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-kontaktieren.jpg">
+                        </picture>
+                    </div>
+                    <div class="cards-card-body">
+                        <p><strong>Audi customer support</strong></p>
+                        <p class="button-container">
+                            <em>
+                                <a href="https://www.audi.co.uk/uk/web/en/connect/contact-us.html"
+                                   title="Contact us" class="button secondary">
+                                    Contact us
+                                </a>
+                            </em>
+                        </p>
+                    </div>
+                </li>
+            </ul>
         </div>
     </div>
 </main>
 <footer></footer>
 </body>
-
 </html>

--- a/404.html
+++ b/404.html
@@ -2,66 +2,81 @@
 <html>
 
 <head>
-  <title>Page not found</title>
-  <script type="text/javascript">
-    window.isErrorPage = true;
-    window.errorCode = '404';
-  </script>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:title" content="Page not found">
-  <script src="/aemedge/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
-  <script type="module">
-    import { sampleRUM } from '/aemedge/scripts/aem.js';
+    <title>Page not found</title>
+    <script type="text/javascript">
+      window.isErrorPage = true;
+      window.errorCode = '404';
+    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:title" content="Page not found">
+    <script src="/aemedge/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+    <script type="module">
+      import { sampleRUM } from '/aemedge/scripts/aem.js';
 
-    window.addEventListener('load', () => {
-      if (document.referrer) {
-        const { origin, pathname } = new URL(document.referrer);
-        if (origin === window.location.origin) {
-          const backBtn = document.createElement('a');
-          backBtn.classList.add('button', 'error-button-back');
-          backBtn.href = pathname;
-          backBtn.textContent = 'Go back';
-          backBtn.title = 'Go back';
-          const btnContainer = document.querySelector('.button-container');
-          btnContainer.append(backBtn);
+      window.addEventListener('load', () => {
+        if (document.referrer) {
+          const {
+            origin,
+            pathname
+          } = new URL(document.referrer);
+          if (origin === window.location.origin) {
+            const backBtn = document.createElement('a');
+            backBtn.classList.add('button', 'error-button-back');
+            backBtn.href = pathname;
+            backBtn.textContent = 'Go back';
+            backBtn.title = 'Go back';
+            const btnContainer = document.querySelector('.button-container');
+            btnContainer.append(backBtn);
+          }
         }
-      }
-      sampleRUM('404', { source: document.referrer, target: window.location.href });
-    });
-  </script>
-  <link rel="stylesheet" href="/aemedge/styles/styles.css">
-  <style>
-    main.error {
-      min-height: calc(100vh - var(--nav-height));
-      display: flex;
-      align-items: center;
-    }
-
-    main.error .error-number {
-      width: 100%;
-    }
-
-    main.error .error-number text {
-      font-family: var(--fixed-font-family);
-    }
-  </style>
-  <link rel="stylesheet" href="/aemedge/styles/lazy-styles.css">
+        sampleRUM('404', {
+          source: document.referrer,
+          target: window.location.href
+        });
+      });
+    </script>
+    <link rel="stylesheet" href="/aemedge/styles/404.css">
+    <link rel="stylesheet" href="/aemedge/styles/styles.css">
+    <link rel="stylesheet" href="/aemedge/styles/lazy-styles.css">
 </head>
 
 <body>
-  <header></header>
-  <main class="error">
-    <div class="section">
-      <svg viewBox="1 0 38 18" class="error-number">
-        <text x="0" y="17">404</text>
-      </svg>
-      <h2 class="error-message">Page Not Found</h2>
-      <p class="button-container">
-        <a href="/" class="button secondary error-button-home">Go home</a>
-      </p>
+<header></header>
+<main class="error">
+    <picture>
+        <source srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=767"
+                data-resize-param="imwidth=767" media="(max-width:767px)">
+        <source class=""
+                srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1023"
+                data-resize-param="imwidth=1023" media="(max-width:1023px)">
+        <source srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1439"
+                data-resize-param="imwidth=1439" media="(max-width:1439px)">
+        <img src="https://www.audi.co.uk//content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1920"
+             data-resize-param="imwidth=1920" alt="1400x438_ade_s2014_47.jpg">
+    </picture>
+    <h1>Sorry, page not found</h1>
+    <div>
+        <p>Page not found (404)</p>
+        <p>This page may have been removed, had its name changed or is temporarily unavailable</p>
+        <ul>
+            <li>
+                <a href="https://www.audi.co.uk/nemo-public/web/en.html" target="_blank">Return to the homepage</a>
+            </li>
+            <li>
+                <a href="https://www.audi.co.uk/uk/web/en/models/all-models.html" target="_blank">Explore models</a>
+            </li>
+        </ul>
     </div>
-  </main>
-  <footer></footer>
+    <div class="cards">
+        <div>
+            <h2>Find your nearest Centre</h2>
+            <img src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-finden.jpg"
+                 alt="320x110_Haendler-finden.jpg">
+            <button>Locate a Centre ></button>
+        </div>
+    </div>
+</main>
+<footer></footer>
 </body>
 
 </html>

--- a/404.html
+++ b/404.html
@@ -2,120 +2,123 @@
 <html>
 
 <head>
-    <title>Page not found</title>
-    <script type="text/javascript">
-      window.isErrorPage = true;
-      window.errorCode = '404';
-    </script>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:title" content="Page not found">
-    <script src="/aemedge/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
-    <script type="module">
-      import { sampleRUM } from '/aemedge/scripts/aem.js';
+  <title>Page not found</title>
+  <script type="text/javascript">
+    window.isErrorPage = true;
+    window.errorCode = '404';
+  </script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:title" content="Page not found">
+  <script src="/aemedge/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script type="module">
+    import { sampleRUM } from '/aemedge/scripts/aem.js';
 
-      window.addEventListener('load', () => {
-        if (document.referrer) {
-          const {
-            origin,
-            pathname
-          } = new URL(document.referrer);
-          if (origin === window.location.origin) {
-            const backBtn = document.createElement('a');
-            backBtn.classList.add('button', 'error-button-back');
-            backBtn.href = pathname;
-            backBtn.textContent = 'Go back';
-            backBtn.title = 'Go back';
-            const btnContainer = document.querySelector('.button-container');
-            btnContainer.append(backBtn);
-          }
+    window.addEventListener('load', () => {
+      if (document.referrer) {
+        const {
+          origin,
+          pathname
+        } = new URL(document.referrer);
+        if (origin === window.location.origin) {
+          const backBtn = document.createElement('a');
+          backBtn.classList.add('button', 'error-button-back');
+          backBtn.href = pathname;
+          backBtn.textContent = 'Go back';
+          backBtn.title = 'Go back';
+          const btnContainer = document.querySelector('.button-container');
+          btnContainer.append(backBtn);
         }
-        sampleRUM('404', {
-          source: document.referrer,
-          target: window.location.href
-        });
+      }
+      sampleRUM('404', {
+        source: document.referrer,
+        target: window.location.href
       });
-    </script>
-    <link rel="stylesheet" href="/aemedge/styles/404.css">
-    <link rel="stylesheet" href="/aemedge/styles/styles.css">
-    <link rel="stylesheet" href="/aemedge/styles/lazy-styles.css">
+    });
+  </script>
+  <link rel="stylesheet" href="/aemedge/styles/404.css">
+  <link rel="stylesheet" href="/aemedge/styles/styles.css">
+  <link rel="stylesheet" href="/aemedge/styles/lazy-styles.css">
 </head>
 
 <body>
 <header></header>
 <main class="error">
-    <picture>
-        <source srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=767"
-                data-resize-param="imwidth=767" media="(max-width:767px)">
-        <source class=""
-                srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1023"
-                data-resize-param="imwidth=1023" media="(max-width:1023px)">
-        <source srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1439"
-                data-resize-param="imwidth=1439" media="(max-width:1439px)">
-        <img src="https://www.audi.co.uk//content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1920"
-             data-resize-param="imwidth=1920" alt="1400x438_ade_s2014_47.jpg">
-    </picture>
-    <h1>Sorry, page not found</h1>
-    <div>
-        <p><strong>Page not found (404)</strong></p>
-        <p>This page may have been removed, had its name changed or is temporarily unavailable</p>
-        <ul>
-            <li>
-                <a href="https://www.audi.co.uk/nemo-public/web/en.html" target="_blank">Return to the homepage</a>
-            </li>
-            <li>
-                <a href="https://www.audi.co.uk/uk/web/en/models/all-models.html" target="_blank">Explore models</a>
-            </li>
-        </ul>
+  <picture>
+    <source
+        srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=767"
+        data-resize-param="imwidth=767" media="(max-width:767px)">
+    <source class=""
+            srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1023"
+            data-resize-param="imwidth=1023" media="(max-width:1023px)">
+    <source
+        srcset="https://www.audi.co.uk/content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1439"
+        data-resize-param="imwidth=1439" media="(max-width:1439px)">
+    <img
+        src="https://www.audi.co.uk//content/dam/nemo/innovation/audi-driving-experience/1400x438_ade_s2014_47.jpg?imwidth=1920"
+        data-resize-param="imwidth=1920" alt="1400x438_ade_s2014_47.jpg">
+  </picture>
+  <h1>Sorry, page not found</h1>
+  <div>
+    <p><strong>Page not found (404)</strong></p>
+    <p>This page may have been removed, had its name changed or is temporarily unavailable</p>
+    <ul>
+      <li>
+        <a href="https://www.audi.co.uk/nemo-public/web/en.html" target="_blank">Return to the homepage</a>
+      </li>
+      <li>
+        <a href="https://www.audi.co.uk/uk/web/en/models/all-models.html" target="_blank">Explore models</a>
+      </li>
+    </ul>
+  </div>
+  <div class="cards-wrapper">
+    <div class="cards block" data-block-name="cards">
+      <ul>
+        <li>
+          <div class="cards-card-image">
+            <picture>
+              <img loading="lazy" alt="320x110_Haendler-finden.jpg"
+                   src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-finden.jpg">
+            </picture>
+          </div>
+          <div class="cards-card-body">
+            <p><strong>Find your nearest Centre</strong></p>
+            <p class="button-container">
+              <em>
+                <a href="https://www.audi.co.uk/uk/web/en/locate-a-centre.html"
+                   title="Locate a Centre" class="button secondary">
+                  Locate a Centre
+                </a>
+              </em>
+            </p>
+          </div>
+        </li>
+      </ul>
     </div>
-    <div class="cards-wrapper">
-        <div class="cards block" data-block-name="cards">
-            <ul>
-                <li>
-                    <div class="cards-card-image">
-                        <picture>
-                            <img loading="lazy" alt="320x110_Haendler-finden.jpg"
-                                 src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-finden.jpg">
-                        </picture>
-                    </div>
-                    <div class="cards-card-body">
-                        <p><strong>Find your nearest Centre</strong></p>
-                        <p class="button-container">
-                            <em>
-                                <a href="https://www.audi.co.uk/uk/web/en/locate-a-centre.html"
-                                   title="Locate a Centre" class="button secondary">
-                                    Locate a Centre
-                                </a>
-                            </em>
-                        </p>
-                    </div>
-                </li>
-            </ul>
-        </div>
 
-        <div class="cards block" data-block-name="cards">
-            <ul>
-                <li>
-                    <div class="cards-card-image">
-                        <picture>
-                            <img loading="lazy" alt="320x110_Haendler-kontaktieren.jpg"
-                                 src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-kontaktieren.jpg">
-                        </picture>
-                    </div>
-                    <div class="cards-card-body">
-                        <p><strong>Audi customer support</strong></p>
-                        <p class="button-container">
-                            <em>
-                                <a href="https://www.audi.co.uk/uk/web/en/connect/contact-us.html"
-                                   title="Contact us" class="button secondary">
-                                    Contact us
-                                </a>
-                            </em>
-                        </p>
-                    </div>
-                </li>
-            </ul>
-        </div>
+    <div class="cards block" data-block-name="cards">
+      <ul>
+        <li>
+          <div class="cards-card-image">
+            <picture>
+              <img loading="lazy" alt="320x110_Haendler-kontaktieren.jpg"
+                   src="https://www.audi.co.uk/dam/nemo/models/misc/contact/320x110_Haendler-kontaktieren.jpg">
+            </picture>
+          </div>
+          <div class="cards-card-body">
+            <p><strong>Audi customer support</strong></p>
+            <p class="button-container">
+              <em>
+                <a href="https://www.audi.co.uk/uk/web/en/connect/contact-us.html"
+                   title="Contact us" class="button secondary">
+                  Contact us
+                </a>
+              </em>
+            </p>
+          </div>
+        </li>
+      </ul>
     </div>
+  </div>
 </main>
 <footer></footer>
 </body>

--- a/aemedge/styles/404.css
+++ b/aemedge/styles/404.css
@@ -9,7 +9,7 @@ main.error {
   }
 }
 
-a:any-link{
+a:any-link {
   display: unset;
 }
 
@@ -34,13 +34,3 @@ main.error ul > li::before {
 main.error ul > li > a::after {
   vertical-align: bottom;
 }
-
-/*div.cards {*/
-/*  display: flex;*/
-/*  flex-direction: column;*/
-
-/*  @media (width >= 600px) {*/
-/*    flex-direction: row;*/
-
-/*  }*/
-/*}*/

--- a/aemedge/styles/404.css
+++ b/aemedge/styles/404.css
@@ -9,6 +9,10 @@ main.error {
   }
 }
 
+a:any-link{
+  display: unset;
+}
+
 /* auto-blocking generated hero */
 .hero.block > div > div > h1 {
   background-color: white;
@@ -31,12 +35,12 @@ main.error ul > li > a::after {
   vertical-align: bottom;
 }
 
-div.cards {
-  display: flex;
-  flex-direction: column;
+/*div.cards {*/
+/*  display: flex;*/
+/*  flex-direction: column;*/
 
-  @media (width >= 600px) {
-    flex-direction: row;
+/*  @media (width >= 600px) {*/
+/*    flex-direction: row;*/
 
-  }
-}
+/*  }*/
+/*}*/

--- a/aemedge/styles/404.css
+++ b/aemedge/styles/404.css
@@ -1,0 +1,42 @@
+main.error {
+  min-height: calc(100vh - var(--nav-height));
+}
+
+@media (width >= 900px) {
+  div.section {
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+}
+
+/* auto-blocking generated hero */
+.hero.block > div > div > h1 {
+  background-color: white;
+  width: fit-content;
+  margin-left: 0;
+  color: black;
+
+  /* todo, -3 is a hack, check if this still works, when we integrate the header on the 404 page */
+  @media (width <= 900px) {
+    position: absolute;
+    top: -3rem;
+  }
+}
+
+main.error ul > li::before {
+  display: none;
+}
+
+main.error ul > li > a::after {
+  vertical-align: bottom;
+}
+
+div.cards {
+  display: flex;
+  flex-direction: column;
+
+  @media (width >= 600px) {
+    flex-direction: row;
+
+  }
+}

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -155,13 +155,6 @@ a:hover {
   color: var(--link-hover-color);
 }
 
-/* only add flex for non-headline elements. */
-:not(h1, h2, h3, h4, h5, h6) > a:any-link {
-  display: flex;
-  align-items: center;
-  word-break: break-all;
-}
-
 /* Add the caret svg to anchors that are not a primary or secondary button */
 a:not(.button)::after {
   content: url('/aemedge/icons/forward.svg');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.3.0",
   "description": "Starter project for Adobe Helix",
   "scripts": {
-    "lint:js": "eslint .",
+    "lint:js": "eslint . --fix",
     "lint:css": "stylelint aemedge/blocks/**/*.css aemedge/styles/*.css",
     "lint": "npm run lint:js && npm run lint:css"
   },


### PR DESCRIPTION
Updates the 404.html page.

- Trying to reuse the "cards" block, by directly including the _final_ html. Needs #8 to be merged beforehand.
- Removes display flex from anchors in styles.css. Using `vertical-align: bottom` is a better method of vertically aligning the forward svg.
  - https://github.com/aemsites/audi/pull/17/files#diff-8a551147d456269165ee59dc422c82faecc56791f27e34074ad6cff6339a1718L159
- The images are referenced as fully-qualified links, helix however, tries to auto optimize them and removes the schema and domain. Therefore, the images cannot be loaded. They _should_ work, as soon as we deploy on the actual `audi.co.uk` page, however, thats too hacky. Any ideas?

Fix #12 

Test URLs:
- Before: https://main--audi--aemsites.hlx.live/404.html
- After: https://12-updates-to-404-page--audi--aemsites.hlx.live/404.html


