### PR TITLE
42 - prepend tools json path with /aemedge

### DIFF
--- a/aemedge/tools/sidekick/config.json
+++ b/aemedge/tools/sidekick/config.json
@@ -5,7 +5,7 @@
             "id": "library",
             "title": "Library",
             "environments": ["edit"],
-            "url": "/tools/sidekick/library.html",
+            "url": "/aemedge/tools/sidekick/library.html",
             "includePaths": ["**.docx**"]
         }
     ]


### PR DESCRIPTION
Fix #42 

Test URLs:
- Before: https://main--audi--aemsites.hlx.live/uk/web/en/used-cars
- After: https://42-fix-config-json--audi--aemsites.hlx.live/uk/web/en/used-cars
